### PR TITLE
Fix container create JSON content type and update API version

### DIFF
--- a/src/main/java/com/amihaiemil/docker/LocalDocker.java
+++ b/src/main/java/com/amihaiemil/docker/LocalDocker.java
@@ -59,7 +59,7 @@ public final class LocalDocker extends RtDocker {
      *     (most likely /var/run/docker.sock).
      */
     public LocalDocker(final File unixSocket){
-        this(unixSocket, "v1.35");
+        this(unixSocket, "v1.43");
     }
 
     /**

--- a/src/main/java/com/amihaiemil/docker/RemoteDocker.java
+++ b/src/main/java/com/amihaiemil/docker/RemoteDocker.java
@@ -46,7 +46,7 @@ import org.apache.http.client.HttpClient;
 public final class RemoteDocker extends RtDocker {
 
     /**
-     * Remote Docker engine. API version is 1.35 by default.
+     * Remote Docker engine. API version is 1.43 by default.
      * @param uri Remote Docker URI.
      * @param keys Path to the keystore.
      * @param trust Path to the truststore.
@@ -56,13 +56,13 @@ public final class RemoteDocker extends RtDocker {
     RemoteDocker(
         final URI uri, final Path keys, final Path trust,
         final char[] storePwd, final char[] keyPwd) {
-        this(uri, "v1.35", keys, trust, storePwd, keyPwd);
+        this(uri, "v1.43", keys, trust, storePwd, keyPwd);
     }
 
     /**
      * Remote Docker engine.
      * @param uri Remote Docker URI.
-     * @param version API version (eg. v1.35).
+     * @param version API version (eg. v1.43).
      * @param keys Path to the keystore.
      * @param trust Path to the truststore.
      * @param storePwd Password for the keystore.
@@ -81,7 +81,7 @@ public final class RemoteDocker extends RtDocker {
     /**
      * Remote Docker engine.
      * 
-     * An insecure docker API v1.35 endpoint is assumed.
+     * An insecure docker API v1.43 endpoint is assumed.
      * 
      * @param uri Remote Docker URI.
      */
@@ -92,7 +92,7 @@ public final class RemoteDocker extends RtDocker {
     /**
      * Remote Docker engine.
      * 
-     * An insecure docker API v1.35 endpoint is assumed.
+     * An insecure docker API v1.43 endpoint is assumed.
      * 
      * @param uri Remote Docker URI.
      * @param auth Remote Docker {@link Auth}
@@ -106,13 +106,13 @@ public final class RemoteDocker extends RtDocker {
      * most likely with some authentication mechanism, depending on where
      * the Docker engine is on the Network. <br><br>
      *
-     * By default, the API version is 1.35.
+     * By default, the API version is 1.43.
      *
      * @param client The http client to use.
      * @param uri Remote Docker URI.
      */
     public RemoteDocker(final HttpClient client, final URI uri) {
-        this(client, uri, "v1.35");
+        this(client, uri, "v1.43");
     }
 
     /**
@@ -122,7 +122,7 @@ public final class RemoteDocker extends RtDocker {
      *
      * @param client The http client to use.
      * @param uri Remote Docker URI.
-     * @param version API version (eg. v1.35).
+     * @param version API version (eg. v1.43).
      */
     public RemoteDocker(
         final HttpClient client, final URI uri, final String version

--- a/src/main/java/com/amihaiemil/docker/RtContainer.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainer.java
@@ -33,7 +33,6 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHeader;
 
 /**
  * Restful Container.
@@ -263,8 +262,12 @@ final class RtContainer extends JsonResource implements Container {
             .build();
         final HttpPost post = new HttpPost(uri);
         try {
-            post.setEntity(new StringEntity(config.toString()));
-            post.setHeader(new BasicHeader("Content-Type", "application/json"));
+            post.setEntity(
+                new StringEntity(
+                    config.toString(),
+                    org.apache.http.entity.ContentType.APPLICATION_JSON
+                )
+            );
             final JsonObject json = this.client.execute(
                 post,
                 new ReadJsonObject(

--- a/src/main/java/com/amihaiemil/docker/RtContainers.java
+++ b/src/main/java/com/amihaiemil/docker/RtContainers.java
@@ -29,7 +29,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.message.BasicHeader;
 import javax.json.Json;
 import javax.json.JsonObject;
 import java.io.IOException;
@@ -116,8 +115,12 @@ abstract class RtContainers implements Containers {
         }
         final HttpPost post = new HttpPost(uri);
         try {
-            post.setEntity(new StringEntity(container.toString()));
-            post.setHeader(new BasicHeader("Content-Type", "application/json"));
+            post.setEntity(
+                new StringEntity(
+                    container.toString(),
+                    org.apache.http.entity.ContentType.APPLICATION_JSON
+                )
+            );
             final JsonObject json = this.client.execute(
                 post,
                 new ReadJsonObject(

--- a/src/main/java/com/amihaiemil/docker/TcpDocker.java
+++ b/src/main/java/com/amihaiemil/docker/TcpDocker.java
@@ -41,7 +41,7 @@ import org.apache.http.client.HttpClient;
 public final class TcpDocker extends RtDocker {
 
     /**
-     * Tcp Docker engine. API version is 1.35 by default.
+     * Tcp Docker engine. API version is 1.43 by default.
      * @param uri Remote Docker URI.
      * @param keys Path to the keystore.
      * @param trust Path to the truststore.
@@ -51,13 +51,13 @@ public final class TcpDocker extends RtDocker {
     TcpDocker(
         final URI uri, final Path keys, final Path trust,
         final char[] storePwd, final char[] keyPwd) {
-        this(uri, "v1.35", keys, trust, storePwd, keyPwd);
+        this(uri, "v1.43", keys, trust, storePwd, keyPwd);
     }
 
     /**
      * Tcp Docker engine.
      * @param uri Remote Docker URI.
-     * @param version API version (eg. v1.35).
+     * @param version API version (eg. v1.43).
      * @param keys Path to the keystore.
      * @param trust Path to the truststore.
      * @param storePwd Password for the keystore.
@@ -76,18 +76,18 @@ public final class TcpDocker extends RtDocker {
     /**
      * Tcp Docker engine.
      * 
-     * An insecure docker API v1.35 endpoint is assumed.
+     * An insecure docker API v1.43 endpoint is assumed.
      * 
      * @param uri Remote Docker URI.
      */
     public TcpDocker(final URI uri) {
         this(new PlainHttpClient(), uri);
-    }    
+    }
     
     /**
      * Tcp Docker engine.
      * 
-     * An insecure docker API v1.35 endpoint is assumed.
+     * An insecure docker API v1.43 endpoint is assumed.
      * 
      * @param uri Remote Docker URI.
      * @param auth Remote Docker {@link Auth}
@@ -101,13 +101,13 @@ public final class TcpDocker extends RtDocker {
      * most likely with some authentication mechanism, depending on where
      * the Docker engine is on the Network. <br><br>
      *
-     * By default, the API version is 1.35.
+     * By default, the API version is 1.43.
      *
      * @param client The http client to use.
      * @param uri Remote Docker URI.
      */
     public TcpDocker(final HttpClient client, final URI uri) {
-        this(client, uri, "v1.35");
+        this(client, uri, "v1.43");
     }
 
     /**
@@ -117,7 +117,7 @@ public final class TcpDocker extends RtDocker {
      *
      * @param client The http client to use.
      * @param uri Remote Docker URI.
-     * @param version API version (eg. v1.35).
+     * @param version API version (eg. v1.43).
      */
     public TcpDocker(
         final HttpClient client, final URI uri, final String version

--- a/src/main/java/com/amihaiemil/docker/UnixDocker.java
+++ b/src/main/java/com/amihaiemil/docker/UnixDocker.java
@@ -53,7 +53,7 @@ public final class UnixDocker extends RtDocker {
      *     (most likely /var/run/docker.sock).
      */
     public UnixDocker(final File unixSocket){
-        this(unixSocket, "v1.35");
+        this(unixSocket, "v1.43");
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure request body uses `Content-Type: application/json`
- bump default Docker Engine API version to `v1.43`

## Testing
- `mvn -q -Pcheckstyle test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840f5bc8a3883328dc701ac1fff3d11